### PR TITLE
Allow extra attributes to be added to offsite links via a filter

### DIFF
--- a/edd-external-products.php
+++ b/edd-external-products.php
@@ -103,7 +103,7 @@ function edd_external_product_link( $purchase_form, $args ) {
 			'<a class="%1$s" href="%2$s" %3$s>%4$s</a>',
 			implode( ' ', array( $args['style'], $args['color'], trim( $args['class'] ) ) ),
 			esc_attr( $external_url ),
-			apply_filters( 'edd_external_product_link_attrs', '' ),
+			apply_filters( 'edd_external_product_link_attrs', '', $args ),
 			esc_attr( $args['text'] )
 		);
 

--- a/edd-external-products.php
+++ b/edd-external-products.php
@@ -100,9 +100,10 @@ function edd_external_product_link( $purchase_form, $args ) {
 
 		// Output an anchor tag with the same classes as the product button
 		$output .= sprintf(
-			'<a class="%1$s" href="%2$s">%3$s</a>',
+			'<a class="%1$s" href="%2$s" %3$s>%4$s</a>',
 			implode( ' ', array( $args['style'], $args['color'], trim( $args['class'] ) ) ),
 			esc_attr( $external_url ),
+			apply_filters( 'edd_external_product_link_attrs', '' ),
 			esc_attr( $args['text'] )
 		);
 


### PR DESCRIPTION
With this change, additional attributes can be added to the offsite links via a filter. Example usage:

Make links open in new window:
```php
function my_external_product_link_attrs( $attributes ) {
	return $attributes . ' target="_blank"';
}
add_filter( 'edd_external_product_link_attrs', 'my_external_product_link_attrs' );
```

Add "nofollow" to all external product links:
```php
function my_external_product_link_attrs( $attributes ) {
	return $attributes . ' rel="nofollow"';
}
add_filter( 'edd_external_product_link_attrs', 'my_external_product_link_attrs' );
```
